### PR TITLE
allow any STREAM frame

### DIFF
--- a/draft-kazuho-quic-quic-services-for-streams.md
+++ b/draft-kazuho-quic-quic-services-for-streams.md
@@ -161,7 +161,7 @@ While the frame format remains unchanged, there are two differences in the
 handling of STREAMS frames between QUIC version 1 and QUIC on Streams.
 
 
-### STREAM frames without the Length Field
+### STREAM Frames without the Length Field
 
 In QUIC on Streams, when a STREAM frame that omits the Length field is used, the
 size of that STREAM frame is determined by the maximum frame size, as regulated

--- a/draft-kazuho-quic-quic-services-for-streams.md
+++ b/draft-kazuho-quic-quic-services-for-streams.md
@@ -161,7 +161,7 @@ While the frame format remains unchanged, there are two differences in the
 handling of STREAMS frames between QUIC version 1 and QUIC on Streams.
 
 
-### Omission of the Length Field
+### STREAM frames without the Length Field
 
 In QUIC on Streams, when a STREAM frame that omits the Length field is used, the
 size of that STREAM frame is determined by the maximum frame size, as regulated


### PR DESCRIPTION
I kind of think that we have made premature optimizations to the STREAM frame design, so this is a different take.

In the approach proposed in this PR:
* Any STREAM frame type is allowed.
* Unless the STREAM frame conveys the beginning of the stream, the frame will have the Offset field. This is indeed an overhead of the wire, but considering that minimum `max_frame_size` is 16KB, the overhead will be around 0.02% (i.e., 4/16834=0.0002, assuming an encoded Offset field of 4 bytes), so who cares?
* When the Length field is omitted, size of the stream is `max_frame_size`. Now that we have the TP, we can do this.